### PR TITLE
Add editorconfig-mcp-server to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [CircleCI/mcp-server-circleci](https://github.com/CircleCI-Public/mcp-server-circleci) 📇 ☁️ Enable AI Agents to fix build failures from CircleCI.
 - [currents-dev/currents-mcp](https://github.com/currents-dev/currents-mcp) 🎖️ 📇 ☁️ Enable AI Agents to fix Playwright test failures reported to [Currents](https://currents.dev).
 - [delano/postman-mcp-server](https://github.com/delano/postman-mcp-server) 📇 ☁️ - Interact with [Postman API](https://www.postman.com/postman/postman-public-workspace/)
+- [editorconfig-mcp-server](https://npmjs.com/package/editorconfig-mcp-server) 📇 🏠 - Formats files using .editorconfig rules, preventing formatting errors from AI coding agents by ensuring files are correct from the start.
 - [flipt-io/mcp-server-flipt](https://github.com/flipt-io/mcp-server-flipt) 📇 🏠 - Enable AI assistants to interact with your feature flags in [Flipt](https://flipt.io).
 - [GLips/Figma-Context-MCP](https://github.com/GLips/Figma-Context-MCP) 📇 🏠 - Provide coding agents direct access to Figma data to help them one-shot design implementation.
 - [gofireflyio/firefly-mcp](https://github.com/gofireflyio/firefly-mcp) 🎖️ 📇 ☁️ - Integrates, discovers, manages, and codifies cloud resources with [Firefly](https://firefly.ai).


### PR DESCRIPTION
This PR adds editorconfig-mcp-server to the Developer Tools section of the awesome-mcp-servers list.

## Summary
- Adds editorconfig-mcp-server (https://npmjs.com/package/editorconfig-mcp-server)
- Positioned alphabetically in the Developer Tools section
- MCP server that formats files using .editorconfig rules to prevent formatting errors from AI coding agents

The server was recently published to npm and provides a solution for proactive formatting to ensure AI-generated code follows project formatting standards from the start.